### PR TITLE
Set min width for datetime

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,7 @@ body {
     padding: 5px;
     width: 25%;
     font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    min-width: 230px;
 }
 .dateTime p {
     margin: 0;


### PR DESCRIPTION
Changed min width of .dateTime to 230px so that the content will not overflow